### PR TITLE
api/net/inet4.hpp - Remove extraneous #includes

### DIFF
--- a/api/net/inet4.hpp
+++ b/api/net/inet4.hpp
@@ -18,9 +18,6 @@
 #ifndef NET_INET4_HPP
 #define NET_INET4_HPP
 
-#include <kernel/syscalls.hpp> // panic()
-#include <hw/devices.hpp> // 107: auto& eth0 = Dev::eth(0);
-#include <hw/nic.hpp>
 #include "inet.hpp"
 #include "ethernet/ethernet.hpp"
 #include "ip4/arp.hpp"


### PR DESCRIPTION
inet4.hpp no longer uses panic() from syscalls.hpp nor Dev:: from an
old version of devices.hpp. <hw/nic.hpp> is already included in the
shared file inet.hpp, so does not need to be included in inet4.hpp
specifically.